### PR TITLE
Only credit cards, check merchantReferences, show config error

### DIFF
--- a/force-app/main/default/classes/AdyenPaymentMethods.cls
+++ b/force-app/main/default/classes/AdyenPaymentMethods.cls
@@ -2,10 +2,10 @@ public with sharing class AdyenPaymentMethods {
     private static PaymentMethodsRequest createPaymentMethodsRequest(String cartId, Merchant__mdt merchant, Boolean isStoredPaymentMethod) {
         PaymentMethodsRequest paymentMethodsRequest = new PaymentMethodsRequest();
         paymentMethodsRequest.merchantAccount = merchant.Merchant_Account__c;
+        paymentMethodsRequest.allowedPaymentMethods = new List<String>{'scheme'};
         if(isStoredPaymentMethod){
-            //Only credit card for My Wallet
+            //No cart through My Wallet
             paymentMethodsRequest.shopperReference = AdyenUtil.getAccountIdFromUser(UserInfo.getUserId()).AccountId;
-            paymentMethodsRequest.allowedPaymentMethods = new List<String>{'scheme'};
         }
         else {
             ccrz__E_Cart__c cart = AdyenUtil.getCartByEncryptedId(cartId);

--- a/force-app/main/default/classes/AdyenReturn.cls
+++ b/force-app/main/default/classes/AdyenReturn.cls
@@ -7,8 +7,12 @@ public with sharing class AdyenReturn {
         Map<String, String> details = getDetails(redirectResult, payload);
         PaymentsResponse paymentsDetailsResponse = AdyenPaymentsDetails.requestAfterRedirect(details, merchantReference);
         Map<String, Object> paymentResult = AdyenResponseHandler.handleResponse(paymentsDetailsResponse);
-
-        if((String)paymentResult.get('merchantReference') == merchantReference){
+        String responseMerchantReference = (String)paymentResult.get('merchantReference');
+        Map<String, Object> additionalData = (Map<String, Object>)paymentResult.get('additionalData');
+        if(!String.isBlank((String)additionalData.get('merchantReference'))){
+            responseMerchantReference = (String)additionalData.get('merchantReference');
+        }
+        if(merchantReference == responseMerchantReference){
             if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED){
                 //Place order
                 Map<String, Object> orderResult = AdyenController.placeOrder(paymentResult, merchantReference);

--- a/force-app/main/default/classes/AdyenReturn.cls
+++ b/force-app/main/default/classes/AdyenReturn.cls
@@ -7,11 +7,8 @@ public with sharing class AdyenReturn {
         Map<String, String> details = getDetails(redirectResult, payload);
         PaymentsResponse paymentsDetailsResponse = AdyenPaymentsDetails.requestAfterRedirect(details, merchantReference);
         Map<String, Object> paymentResult = AdyenResponseHandler.handleResponse(paymentsDetailsResponse);
-        String responseMerchantReference = (String)paymentResult.get('merchantReference');
         Map<String, Object> additionalData = (Map<String, Object>)paymentResult.get('additionalData');
-        if(!String.isBlank((String)additionalData.get('merchantReference'))){
-            responseMerchantReference = (String)additionalData.get('merchantReference');
-        }
+        String responseMerchantReference = !String.isBlank((String)additionalData.get('merchantReference')) ? (String)additionalData.get('merchantReference') : (String)paymentResult.get('merchantReference');
         if(merchantReference == responseMerchantReference){
             if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED){
                 //Place order

--- a/force-app/main/default/staticresources/adyenCheckout.js
+++ b/force-app/main/default/staticresources/adyenCheckout.js
@@ -13,11 +13,16 @@ renderAdyenComponent = paymentMethodsResponse => {
     };
     checkout.adyenCheckout = new AdyenCheckout(configuration);
 
-    paymentMethodsResponse.paymentMethods.forEach((pm) =>
-        renderPaymentMethod(pm)
-    );
+    if(paymentMethodsResponse.paymentMethods.length > 0) {
+        paymentMethodsResponse.paymentMethods.forEach((pm) =>
+            renderPaymentMethod(pm)
+        );
+        selectFirstPaymentMethod();
+    }
+    else {
+        console.error('No payment methods available, please verify Adyen configuration');
+    }
 
-    selectFirstPaymentMethod();
 }
 
 getPaymentMethodsConfig = () => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Display only credit cards in the checkout
Compare merchantReference on returnUrl after redirect 3DS1 
Show configuration error if Adyen not configured correctly (merchantAccount, API key)

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
