### PR TITLE
PW-4836 Store card after 3DS 

### DIFF
--- a/force-app/main/default/classes/AdyenController.cls
+++ b/force-app/main/default/classes/AdyenController.cls
@@ -21,11 +21,11 @@ global inherited sharing class AdyenController {
     public static String handleOnAdditionalDetails(String stateData, String storefrontName){
         Map<String, Object> requestData = (Map<String, Object>)JSON.deserializeUntyped(stateData);
         String cartId = (String)requestData.get('cartId');
-        ccrz.cc_hk_Payment paymentHook = ccrz.cc_hk_Payment.getInstance(null);
-        Map<String, Object> paymentProcessorInput = AdyenController.createProcessorInput(cartId, stateData, 'paymentsDetails');
-        Map<String, Object> processResult = paymentHook.processPayment(paymentProcessorInput);
+
+        Map<String, Object> adyenResult = callAdyenPaymentHook(cartId, stateData, 'paymentsDetails');
+
         Boolean zeroAuthSuccess = false;
-        Map<String, Object> paymentResult = (Map<String, Object>) processResult.get('paymentResult');
+        Map<String, Object> paymentResult = (Map<String, Object>) adyenResult.get('paymentResult');
         Map<String, String> additionalData = (Map<String, String>)paymentResult.get('additionalData');
         String merchantReference = (String)paymentResult.get('merchantReference');
         if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED && (merchantReference == cartId || merchantReference.contains('addStoredMethod'))) {
@@ -34,7 +34,7 @@ global inherited sharing class AdyenController {
             }
             else {
                 //create order
-                Map<String, Object> orderResult = AdyenController.placeOrder(processResult, cartId);
+                Map<String, Object> orderResult = AdyenController.placeOrder(adyenResult, cartId);
                 Map<String, String> orderIds = AdyenController.validateOrderResult(orderResult);
                 //Return orderId for confirmation page
                 paymentResult.put('orderIdEnc', orderIds.get('orderIdEnc'));
@@ -47,6 +47,13 @@ global inherited sharing class AdyenController {
         paymentResult.put('zeroAuthSuccess', zeroAuthSuccess);
         return JSON.serialize(paymentResult, true);
     }
+
+    public static Map<String, Object> callAdyenPaymentHook(String cartId, String stateData, String adyenEndpoint){
+        ccrz.cc_hk_Payment paymentHook = ccrz.cc_hk_Payment.getInstance(null);
+        Map<String, Object> paymentProcessorInput = AdyenController.createProcessorInput(cartId, stateData, adyenEndpoint);
+        return paymentHook.processPayment(paymentProcessorInput);
+    }
+
     public static void checkToStorePaymentMethod(Map<String, String> additionalData, string storefrontName){
         String token = additionalData.get('recurring_recurringDetailReference');
         if(!String.isBlank(token)){

--- a/force-app/main/default/classes/AdyenController.cls
+++ b/force-app/main/default/classes/AdyenController.cls
@@ -26,23 +26,23 @@ global inherited sharing class AdyenController {
         Map<String, Object> processResult = paymentHook.processPayment(paymentProcessorInput);
         Boolean zeroAuthSuccess = false;
         Map<String, Object> paymentResult = (Map<String, Object>) processResult.get('paymentResult');
-        if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED) {
-            String merchantReference = (String)paymentResult.get('merchantReference');
-            if(merchantReference == cartId){
+        Map<String, String> additionalData = (Map<String, String>)paymentResult.get('additionalData');
+        String merchantReference = (String)paymentResult.get('merchantReference');
+        if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED && (merchantReference == cartId || merchantReference.contains('addStoredMethod'))) {
+            if(merchantReference.contains('addStoredMethod')){
+                zeroAuthSuccess = true;
+            }
+            else {
                 //create order
                 Map<String, Object> orderResult = AdyenController.placeOrder(processResult, cartId);
                 Map<String, String> orderIds = AdyenController.validateOrderResult(orderResult);
                 //Return orderId for confirmation page
                 paymentResult.put('orderIdEnc', orderIds.get('orderIdEnc'));
             }
-            else if(merchantReference.contains('addStoredMethod')){
-                Map<String, String> additionalData = (Map<String, String>)paymentResult.get('additionalData');
-                AdyenController.checkToStorePaymentMethod(additionalData, storefrontName);
-                zeroAuthSuccess = true;
-            }
-            else {
-                System.debug('Invalid merchantReference: ' + merchantReference);
-            }
+            AdyenController.checkToStorePaymentMethod(additionalData, storefrontName);
+        }
+        else {
+                System.debug('Payment failed or invalid merchantReference: ' + merchantReference);
         }
         paymentResult.put('zeroAuthSuccess', zeroAuthSuccess);
         return JSON.serialize(paymentResult, true);

--- a/force-app/main/default/classes/AdyenController.cls
+++ b/force-app/main/default/classes/AdyenController.cls
@@ -18,12 +18,41 @@ global inherited sharing class AdyenController {
        return handlePaymentsDetailsCall(stateData);
     }
 
-    public static void checkToStorePaymentMethod(Map<String, String> additionalData, ccrz.cc_RemoteActionResult res){
+    public static String handleOnAdditionalDetails(String stateData, String storefrontName){
+        Map<String, Object> requestData = (Map<String, Object>)JSON.deserializeUntyped(stateData);
+        String cartId = (String)requestData.get('cartId');
+        ccrz.cc_hk_Payment paymentHook = ccrz.cc_hk_Payment.getInstance(null);
+        Map<String, Object> paymentProcessorInput = AdyenController.createProcessorInput(cartId, stateData, 'paymentsDetails');
+        Map<String, Object> processResult = paymentHook.processPayment(paymentProcessorInput);
+        Boolean zeroAuthSuccess = false;
+        Map<String, Object> paymentResult = (Map<String, Object>) processResult.get('paymentResult');
+        if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED) {
+            String merchantReference = (String)paymentResult.get('merchantReference');
+            if(merchantReference == cartId){
+                //create order
+                Map<String, Object> orderResult = AdyenController.placeOrder(processResult, cartId);
+                Map<String, String> orderIds = AdyenController.validateOrderResult(orderResult);
+                //Return orderId for confirmation page
+                paymentResult.put('orderIdEnc', orderIds.get('orderIdEnc'));
+            }
+            else if(merchantReference.contains('addStoredMethod')){
+                Map<String, String> additionalData = (Map<String, String>)paymentResult.get('additionalData');
+                AdyenController.checkToStorePaymentMethod(additionalData, storefrontName);
+                zeroAuthSuccess = true;
+            }
+            else {
+                System.debug('Invalid merchantReference: ' + merchantReference);
+            }
+        }
+        paymentResult.put('zeroAuthSuccess', zeroAuthSuccess);
+        return JSON.serialize(paymentResult, true);
+    }
+    public static void checkToStorePaymentMethod(Map<String, String> additionalData, string storefrontName){
         String token = additionalData.get('recurring_recurringDetailReference');
         if(!String.isBlank(token)){
             List<ccrz__E_StoredPayment__c> existingStoredPayments = AdyenUtil.getStoredPaymentByToken(token);
             if(existingStoredPayments.isEmpty()){
-                createStoredPaymentMethod(additionalData, res);
+                createStoredPaymentMethod(additionalData, storefrontName);
             }
             else {
                 updateStoredPaymentMethod(existingStoredPayments, additionalData);
@@ -34,7 +63,7 @@ global inherited sharing class AdyenController {
         }
     }
 
-    private static void createStoredPaymentMethod(Map<String, String> additionalData, ccrz.cc_RemoteActionResult res){
+    private static void createStoredPaymentMethod(Map<String, String> additionalData, String storefrontName){
         ccrz__E_StoredPayment__c storedPayment = new ccrz__E_StoredPayment__c();
         storedPayment.ccrz__Enabled__c = true;
         storedPayment.ccrz__Token__c = additionalData.get('recurring_recurringDetailReference');
@@ -42,7 +71,7 @@ global inherited sharing class AdyenController {
         storedPayment.ccrz__Account__c = AdyenUtil.getAccountIdFromUser(UserInfo.getUserId()).AccountId;
         storedPayment.ccrz__AccountNumber__c = (String)additionalData.get('cardBin') + '******' + (String)additionalData.get('cardSummary');
         storedPayment.ccrz__User__c = UserInfo.getUserId();
-        storedPayment.ccrz__Storefront__c = res.inputContext.storeFront;
+        storedPayment.ccrz__Storefront__c = storefrontName;
         storedPayment.ccrz__AccountType__c = 'adyencc';
         List<String> expiryDate = additionalData.get('expiryDate').split('/');
         storedPayment.ccrz__ExpMonth__c = Decimal.valueOf(expiryDate.get(0));

--- a/force-app/main/default/classes/AdyenReturn.cls
+++ b/force-app/main/default/classes/AdyenReturn.cls
@@ -7,22 +7,28 @@ public with sharing class AdyenReturn {
         Map<String, String> details = getDetails(redirectResult, payload);
         PaymentsResponse paymentsDetailsResponse = AdyenPaymentsDetails.requestAfterRedirect(details, merchantReference);
         Map<String, Object> paymentResult = AdyenResponseHandler.handleResponse(paymentsDetailsResponse);
-        Map<String, Object> additionalData = (Map<String, Object>)paymentResult.get('additionalData');
+        Map<String, String> additionalData = (Map<String, String>)paymentResult.get('additionalData');
         String responseMerchantReference = !String.isBlank((String)additionalData.get('merchantReference')) ? (String)additionalData.get('merchantReference') : (String)paymentResult.get('merchantReference');
-        if(merchantReference == responseMerchantReference){
-            if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED){
-                //Place order
-                Map<String, Object> orderResult = AdyenController.placeOrder(paymentResult, merchantReference);
-                Map<String, String> orderIds = AdyenController.validateOrderResult(orderResult);
-                String orderId = orderIds.get('orderIdEnc');
-                PageReference pageRef = new PageReference(Site.getBaseSecureUrl() + '/ccrz__OrderConfirmation?o=' + orderId);
-                pageRef.setRedirect(true);
-                return pageRef;
+        Boolean isMyWallet = responseMerchantReference.contains('addStoredMethod');
+        //TODOBAS add Payment Failed error message
+        PageReference pageReference = isMyWallet ? new PageReference(Site.getBaseSecureUrl() + '/ccrz__MyAccount?viewState=myWallet?paymentFailed=true') : new PageReference(Site.getBaseSecureUrl() + '/ccrz__CheckoutNew?paymentFailed=true?cartID=' + merchantReference);
+        if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED) {
+            if(merchantReference == responseMerchantReference || isMyWallet){
+                pageReference = new PageReference(Site.getBaseSecureUrl() + '/ccrz__MyAccount?viewState=myWallet');
+                if(!isMyWallet){
+                    //create order
+                    Map<String, Object> orderResult = AdyenController.placeOrder(paymentResult, merchantReference);
+                    Map<String, String> orderIds = AdyenController.validateOrderResult(orderResult);
+                    String orderId = orderIds.get('orderIdEnc');
+                    pageReference = new PageReference(Site.getBaseSecureUrl() + '/ccrz__OrderConfirmation?o=' + orderId);
+                }
+                AdyenController.checkToStorePaymentMethod(additionalData, ccrz.cc_CallContext.storefront);
+            }
+            else {
+                System.debug('Invalid merchantReference: ' + merchantReference);
             }
         }
 
-        //TODOBAS add Payment Failed error message
-        PageReference pageReference = new PageReference(Site.getBaseSecureUrl() + '/ccrz__CheckoutNew?cartID=' + merchantReference);
         pageReference.setRedirect(true);
         return pageReference;
     }

--- a/force-app/main/default/classes/PmtAdyenNewController.cls
+++ b/force-app/main/default/classes/PmtAdyenNewController.cls
@@ -26,6 +26,13 @@ global with sharing class PmtAdyenNewController {
     }
 
     @RemoteAction
+    global static String handleOnAdditionalDetails(ccrz.cc_RemoteActionContext ctx, String details){
+        ccrz.cc_RemoteActionResult res = ccrz.cc_CallContext.init(ctx);
+        String storefrontName = res.inputContext.storeFront;
+        return AdyenController.handleOnAdditionalDetails(details, storefrontName);
+    }
+
+    @RemoteAction
     global static ccrz.cc_RemoteActionResult addAdyenccStoredPayment(ccrz.cc_RemoteActionContext ctx, String stateData)
     {
         ccrz.cc_RemoteActionResult res = ccrz.cc_CallContext.init(ctx);
@@ -39,7 +46,7 @@ global with sharing class PmtAdyenNewController {
 
             if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED) {
                 Map<String, String> additionalData = (Map<String, String>)paymentResult.get('additionalData');
-                AdyenController.checkToStorePaymentMethod(additionalData, res);
+                AdyenController.checkToStorePaymentMethod(additionalData, res.inputContext.storeFront);
                 res.success = true;
                 return res;
             }

--- a/force-app/main/default/classes/PmtAdyenPayController.cls
+++ b/force-app/main/default/classes/PmtAdyenPayController.cls
@@ -10,11 +10,9 @@ global with sharing class PmtAdyenPayController {
     global static ccrz.cc_RemoteActionResult placeOrderAdyen(ccrz.cc_RemoteActionContext ctx, String stateData) {
         ccrz.cc_RemoteActionResult res = ccrz.cc_CallContext.init(ctx);
         try {
-            ccrz.cc_hk_Payment paymentHook = ccrz.cc_hk_Payment.getInstance(null);
             ccrz__E_Cart__c cart = AdyenUtil.getCartByEncryptedId(ctx.currentCartId);
-            Map<String, Object> paymentProcessorInput = AdyenController.createProcessorInput(ctx.currentCartId, stateData, 'payments');
-            Map<String, Object> processResult = paymentHook.processPayment(paymentProcessorInput);
-            Map<String, Object> paymentResult = (Map<String, Object>) processResult.get('paymentResult');
+            Map<String, Object> adyenResult = AdyenController.callAdyenPaymentHook(ctx.currentCartId, stateData, 'payments');
+            Map<String, Object> paymentResult = (Map<String, Object>) adyenResult.get('paymentResult');
             if (!(Boolean)paymentResult.get('isFinal')) {
                 cart.AdyenPaymentData__c = (String)paymentResult.get('paymentData');
                 update cart;
@@ -26,7 +24,7 @@ global with sharing class PmtAdyenPayController {
                 Map<String, String> additionalData = (Map<String, String>)paymentResult.get('additionalData');
                 AdyenController.checkToStorePaymentMethod(additionalData, res.inputContext.storeFront);
                 //create order
-                Map<String, Object> orderResult = AdyenController.placeOrder(processResult, cart.ccrz__EncryptedId__c);
+                Map<String, Object> orderResult = AdyenController.placeOrder(adyenResult, cart.ccrz__EncryptedId__c);
                 Map<String, String> orderIds = AdyenController.validateOrderResult(orderResult);
                 //Return orderId for confirmation page
                 paymentResult.put('orderIdEnc', orderIds.get('orderIdEnc'));

--- a/force-app/main/default/classes/PmtAdyenPayController.cls
+++ b/force-app/main/default/classes/PmtAdyenPayController.cls
@@ -24,7 +24,7 @@ global with sharing class PmtAdyenPayController {
             }
             if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED) {
                 Map<String, String> additionalData = (Map<String, String>)paymentResult.get('additionalData');
-                AdyenController.checkToStorePaymentMethod(additionalData, res);
+                AdyenController.checkToStorePaymentMethod(additionalData, res.inputContext.storeFront);
                 //create order
                 Map<String, Object> orderResult = AdyenController.placeOrder(processResult, cart.ccrz__EncryptedId__c);
                 Map<String, String> orderIds = AdyenController.validateOrderResult(orderResult);
@@ -49,5 +49,12 @@ global with sharing class PmtAdyenPayController {
             ccrz.ccLog.close(res);
         }
         return res;
+    }
+
+    @RemoteAction
+    global static String handleOnAdditionalDetails(ccrz.cc_RemoteActionContext ctx, String details){
+        ccrz.cc_RemoteActionResult res = ccrz.cc_CallContext.init(ctx);
+        String storefrontName = res.inputContext.storeFront;
+        return AdyenController.handleOnAdditionalDetails(details, storefrontName);
     }
 }

--- a/force-app/main/default/classes/PmtAdyenStoredController.cls
+++ b/force-app/main/default/classes/PmtAdyenStoredController.cls
@@ -3,11 +3,9 @@ global with sharing class PmtAdyenStoredController {
     global static ccrz.cc_RemoteActionResult placeOrderByStoredPaymentAdyen(ccrz.cc_RemoteActionContext ctx, String stateData) {
         ccrz.cc_RemoteActionResult res = ccrz.cc_CallContext.init(ctx);
         try {
-            ccrz.cc_hk_Payment paymentHook = ccrz.cc_hk_Payment.getInstance(null);
             ccrz__E_Cart__c cart = AdyenUtil.getCartByEncryptedId(ctx.currentCartId);
-            Map<String, Object> paymentProcessorInput = AdyenController.createProcessorInput(ctx.currentCartId, stateData, 'payments');
-            Map<String, Object> processResult = paymentHook.processPayment(paymentProcessorInput);
-            Map<String, Object> paymentResult = (Map<String, Object>) processResult.get('paymentResult');
+            Map<String, Object> adyenResult = AdyenController.callAdyenPaymentHook(ctx.currentCartId, stateData, 'payments');
+            Map<String, Object> paymentResult = (Map<String, Object>) adyenResult.get('paymentResult');
             if (!(Boolean)paymentResult.get('isFinal')) {
                 cart.AdyenPaymentData__c = (String)paymentResult.get('paymentData');
                 update cart;
@@ -17,7 +15,7 @@ global with sharing class PmtAdyenStoredController {
             }
             if (paymentResult.get('resultCode') == PaymentsResponse.ResultCodeEnum.AUTHORISED) {
                 //create order
-                Map<String, Object> orderResult = AdyenController.placeOrder(processResult, cart.ccrz__EncryptedId__c);
+                Map<String, Object> orderResult = AdyenController.placeOrder(adyenResult, cart.ccrz__EncryptedId__c);
                 Map<String, String> orderIds = AdyenController.validateOrderResult(orderResult);
                 //Return orderId for confirmation page
                 paymentResult.put('orderIdEnc', orderIds.get('orderIdEnc'));

--- a/force-app/main/default/staticresources/adyenCheckout.js
+++ b/force-app/main/default/staticresources/adyenCheckout.js
@@ -51,10 +51,7 @@ handleOnAdditionalDetails = (state, component) => {
         cartId: window.cartId,
     };
 
-    let controllerAction = 'PmtAdyenPayController.handleOnAdditionalDetails';
-    if(CCRZ.pagevars.currentPageName === "ccrz__StoredPaymentDetail"){
-        controllerAction = 'PmtAdyenNewController.handleOnAdditionalDetails';
-    }
+    let controllerAction = CCRZ.pagevars.currentPageName === 'ccrz__StoredPaymentDetail' ? 'PmtAdyenNewController.handleOnAdditionalDetails' : 'PmtAdyenPayController.handleOnAdditionalDetails';
 
     Visualforce.remoting.Manager.invokeAction(
         controllerAction,

--- a/force-app/main/default/staticresources/adyenCheckout.js
+++ b/force-app/main/default/staticresources/adyenCheckout.js
@@ -48,21 +48,23 @@ handleOnChange = state => {
 handleOnAdditionalDetails = (state, component) => {
     const details = {
         ...state.data,
-        cartId: window.cartId
+        cartId: window.cartId,
     };
-    $.ajax({
-        type: 'POST',
-        data: JSON.stringify(details),
-        dataType: 'text',
-        contentType: "application/json; charset=utf-8",
-        cache: false,
-        url: '/services/apexrest/AdyenService/',
-        success: function(data)
-        {
-            const result = JSON.parse(JSON.parse(data));
-            return handlePaymentResult(result);
-        }
-    });
+
+    let controllerAction = 'PmtAdyenPayController.handleOnAdditionalDetails';
+    if(CCRZ.pagevars.currentPageName === "ccrz__StoredPaymentDetail"){
+        controllerAction = 'PmtAdyenNewController.handleOnAdditionalDetails';
+    }
+
+    Visualforce.remoting.Manager.invokeAction(
+        controllerAction,
+        CCRZ.pagevars.remoteContext,
+        JSON.stringify(details),
+        function(result, event){
+            const jsonResult = convertToJsonObject(result);
+            return handlePaymentResult(jsonResult);
+        },
+    );
 }
 
 renderPaymentMethod = paymentMethod => {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When shopper selects "save card", store payment method after 3DS1 and 3DS2 transactions. 
Place order after 3DS transactions.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
